### PR TITLE
Escape format string in raw_message before send to syslog

### DIFF
--- a/bin/worker.rb
+++ b/bin/worker.rb
@@ -8,7 +8,7 @@ Bundler.require(:default, ENV['ECHIDNA_ENV'] || "development")
 while true
   $redis.incr "streaming/messages/incoming"
   raw_message = $redis.blpop "streaming/messages", 0
-  $logger.notice("streaming receive message: #{raw_message}")
+  $logger.notice("streaming receive message: #{raw_message.replace('%', '%%')}")
   message = MultiJson.decode raw_message.last
   case message["type"]
   when "add_user"


### PR DESCRIPTION
This fix the crash of worker.
